### PR TITLE
Add configurable clip_sample_n_frames parameter

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -563,7 +563,8 @@ def main():
             cond_file_path=args.validation_reference_path,
             seed=args.seed,
             overlap_window_length=args.overlap_window_length,
-            overlapping_weight_scheme=args.overlapping_weight_scheme
+            overlapping_weight_scheme=args.overlapping_weight_scheme,
+            clip_length=clip_sample_n_frames  # Pass clip_length parameter
         ).videos
         del pipeline
         saved_frames_dir = os.path.join(args.output_dir, "animated_images")


### PR DESCRIPTION
  This is a fix for the parameter 'clip_sample_n_frames', which is fixed in 
  app.py but configurable in inference.py. However, it couldn't be set to values
   different from 81 due to many hardcoded places in the code. You can find them
   in the commit changes. After debugging with Claude Code, now this parameter 
  is truly configurable and will affect the inference. In my tests, 
   clip_sample_n_frames = 125 leads to the fastest inference speed per step. Most
   code was debugged by Claude Code but the results were tested manually by
  myself. Below is the conclusion from Claude Code for this pull request:

  ## Summary
  - Added configurable `clip_sample_n_frames` parameter to improve flexibility
  in video generation
  - Removed hardcoded frame numbers in transformer and vocal projector models
  - Added improved generation logging with timestamp and parameter tracking

  ## Changes
  1. **app.py**: Added `clip_sample_n_frames` slider to Gradio UI (range 17-65,
  default 49)
  2. **inference.py**: Added `--clip_sample_n_frames` argument for CLI usage
  3. **wan/models/vocal_projector_fantasy_1B.py**: Made frame dimensions 
  configurable instead of hardcoded
  4. **wan/models/wan_fantasy_transformer3d_1B.py**: Updated transformer to use
  configurable frames
  5. **wan/pipeline/wan_inference_long_pipeline.py**: Implemented configurable 
  frames in pipeline with validation

  ## Benefits
  - Users can now adjust frame batch size based on their GPU memory
  - Better support for different hardware configurations (from consumer GPUs to 
  H100)
  - Maintains backward compatibility with default value of 49 frames
  - Improved logging helps track generation parameters

  ## Test Plan
  - [x] Verify imports and module loading
  - [x] Test with different clip_sample_n_frames values (17, 33, 49, 65, 125)
  - [x] Confirm backward compatibility with existing configs
  - [x] Test on both Gradio UI and CLI interfaces

  🤖 Generated with [Claude Code](https://claude.ai/code)